### PR TITLE
Fix application launch issues with robust error handling

### DIFF
--- a/wpf/App.xaml.cs
+++ b/wpf/App.xaml.cs
@@ -16,7 +16,15 @@ namespace RemainingTimeMeter
         /// </summary>
         public App()
         {
-            Logger.Info("Application starting up");
+            try
+            {
+                Logger.Info("Application starting up");
+            }
+            catch
+            {
+                // Ignore logging errors during startup
+            }
+
             this.Startup += this.App_Startup;
             this.Exit += this.App_Exit;
         }
@@ -28,7 +36,14 @@ namespace RemainingTimeMeter
         /// <param name="e">The event arguments.</param>
         private void App_Startup(object sender, StartupEventArgs e)
         {
-            Logger.Info($"Application startup completed. Log file: {Logger.LogFile}");
+            try
+            {
+                Logger.Info($"Application startup completed. Log file: {Logger.LogFile}");
+            }
+            catch
+            {
+                // Ignore logging errors
+            }
         }
 
         /// <summary>
@@ -38,7 +53,14 @@ namespace RemainingTimeMeter
         /// <param name="e">The event arguments.</param>
         private void App_Exit(object sender, ExitEventArgs e)
         {
-            Logger.Info($"Application exiting with code: {e.ApplicationExitCode}");
+            try
+            {
+                Logger.Info($"Application exiting with code: {e.ApplicationExitCode}");
+            }
+            catch
+            {
+                // Ignore logging errors
+            }
         }
     }
 }

--- a/wpf/Logger.cs
+++ b/wpf/Logger.cs
@@ -22,16 +22,26 @@ namespace RemainingTimeMeter
         /// </summary>
         static Logger()
         {
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            LogDirectory = Path.Combine(appDataPath, "RemainingTimeMeter");
-
-            if (!Directory.Exists(LogDirectory))
+            try
             {
-                Directory.CreateDirectory(LogDirectory);
-            }
+                string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                LogDirectory = Path.Combine(appDataPath, "RemainingTimeMeter");
 
-            string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-            LogFileInternal = Path.Combine(LogDirectory, $"debug_{timestamp}.log");
+                if (!Directory.Exists(LogDirectory))
+                {
+                    Directory.CreateDirectory(LogDirectory);
+                }
+
+                string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                LogFileInternal = Path.Combine(LogDirectory, $"debug_{timestamp}.log");
+            }
+            catch (Exception)
+            {
+                // If we can't create the log directory, use temp directory as fallback
+                LogDirectory = Path.GetTempPath();
+                string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                LogFileInternal = Path.Combine(LogDirectory, $"RemainingTimeMeter_debug_{timestamp}.log");
+            }
         }
 
         /// <summary>

--- a/wpf/RemainingTimeMeter.csproj
+++ b/wpf/RemainingTimeMeter.csproj
@@ -34,7 +34,6 @@
 
     <ItemGroup>
         <Resource Include="tv_timekeeper_trimmed.ico" />
-        <None Remove="tv_timekeeper.ico" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Fix potential application launch failures due to logging initialization errors
- Add robust error handling to prevent crashes during startup
- Ensure application can run even in restrictive environments

## Problem
The application could fail to launch if:
1. The Logger's static constructor failed when trying to create directories
2. File system permissions were restrictive
3. The application was run from a protected location

This would cause the entire application to crash before the main window could even be displayed.

## Changes Made

### 1. Logger Static Constructor Enhancement
- Added try-catch block around directory creation logic
- Falls back to temp directory if LocalApplicationData is inaccessible
- Prevents TypeInitializationException from crashing the app

### 2. App Startup Logging Protection
- Wrapped all Logger calls in try-catch blocks in App.xaml.cs
- Ensures logging failures don't prevent application startup
- Application continues to run even if logging subsystem fails

### 3. Project File Cleanup
- Removed obsolete reference to deleted tv_timekeeper.ico file
- Fixes potential build warnings

## Test plan
- [x] Build succeeds in both Debug and Release configurations
- [ ] Application launches successfully on a clean system
- [ ] Application launches when LocalApplicationData is restricted
- [ ] Application launches when run from read-only location
- [ ] Verify logging works when permissions allow
- [ ] Verify app runs without logging when permissions deny

🤖 Generated with [Claude Code](https://claude.ai/code)