### PR TITLE
Fix GitHub Actions publishing to disable trimming for WPF applications

### DIFF
--- a/.github/workflows/build-wpf.yml
+++ b/.github/workflows/build-wpf.yml
@@ -34,10 +34,10 @@ jobs:
       
     # Self-contained builds (大きいサイズ、.NETランタイム不要)
     - name: Publish Self-contained Windows x64
-      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true --output ./publish/self-contained/win-x64
+      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false --output ./publish/self-contained/win-x64
       
     - name: Publish Self-contained Windows x86
-      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true --output ./publish/self-contained/win-x86
+      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false --output ./publish/self-contained/win-x86
       
     # Framework-dependent artifacts
     - name: Upload Framework-dependent Windows x64 artifact
@@ -178,10 +178,10 @@ jobs:
       
     # Self-contained builds for release
     - name: Publish Self-contained Windows x64 for Release
-      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true --output ./release/self-contained/win-x64
+      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false --output ./release/self-contained/win-x64
       
     - name: Publish Self-contained Windows x86 for Release
-      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true --output ./release/self-contained/win-x86
+      run: dotnet publish wpf/RemainingTimeMeter.csproj -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false --output ./release/self-contained/win-x86
       
     # Rename files for clarity
     - name: Rename release files


### PR DESCRIPTION
## Summary
- Add `-p:PublishTrimmed=false` to all self-contained publish commands in GitHub Actions workflow
- Ensures consistency with Makefile publish target which already correctly disables trimming
- Fixes runtime failures in released executables

## Problem
The Makefile uses `--property:PublishTrimmed=false` but the GitHub Actions workflow was missing this parameter. This caused WPF assemblies to be trimmed during publishing, leading to runtime failures when users download and run the released executables.

## Solution
- Add `-p:PublishTrimmed=false` to all self-contained publish steps
- Maintain consistency between local builds (Makefile) and CI builds (GitHub Actions)
- Ensure WPF applications can launch properly from GitHub releases

## Test plan
- [x] Verify all self-contained publish commands now include trimming disablement
- [x] Confirm workflow syntax is correct
- [ ] Test that next release generates working executables

🤖 Generated with [Claude Code](https://claude.ai/code)